### PR TITLE
Integration of my clientemail branch and Daniel's request-Form, plus Admin controller, routes, and middleware

### DIFF
--- a/src/controllers/RequestApprovalController.ts
+++ b/src/controllers/RequestApprovalController.ts
@@ -1,0 +1,40 @@
+import { Request, Response } from "express";
+import { RequestApprovalService } from "../services/RequestApprovalService";
+import { RequestFormRepository } from "../repositories/RequestFormRepository";
+
+export class RequestApprovalController {
+  private service: RequestApprovalService;
+  private repository: RequestFormRepository;
+
+  constructor() {
+    this.service = new RequestApprovalService();
+    this.repository = new RequestFormRepository();
+  }
+
+  async approveRequest(req: Request, res: Response) {
+    try {
+      const { requestId } = req.params;
+      const signupBaseUrl = process.env.FRONTEND_URL + '/signup';
+      
+      await this.service.approveRequest(parseInt(requestId, 10), signupBaseUrl);
+      
+      res.status(200).json({ 
+        success: true, 
+        message: "Request approved and email sent" 
+      });
+    } catch (error) {
+      console.error("Error approving request:", error);
+      res.status(500).json({ error: error.message });
+    }
+  }
+
+  async getPendingRequests(req: Request, res: Response) {
+    try {
+      const requests = await this.repository.getAllPendingRequests();
+      res.status(200).json(requests);
+    } catch (error) {
+      console.error("Error fetching pending requests:", error);
+      res.status(500).json({ error: error.message });
+    }
+  }
+}

--- a/src/controllers/RequestFormController.ts
+++ b/src/controllers/RequestFormController.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from "express";
-import { RequestFormService } from "../Services/RequestFormService";
-import { RequestForm } from "../Entities/RequestForm";
+import { RequestFormService } from "../services/RequestFormService";
 
 
 export class RequestFormController{
@@ -13,13 +12,18 @@ export class RequestFormController{
 
     async createForm(req: Request, res: Response){
         try {
+            if (!req.body) {
+              return res.status(400).json({ error: 'No body found in request' });
+            }
+        
             const formData = req.body;
             await this.service.newForm(formData);
-            res.status(200).json({message: "Form data recieved, now onto processing"})
+            res.status(200).json({ message: "Form data received, onto processing" });
             
-        } catch (error) {
-            res.status(400).json({error})
-        }
+          } catch (error) {
+            console.error("Error processing form data:", error);
+            res.status(400).json({ error: error.message });
+          }
 
     }
     

--- a/src/entities/RequestForm.ts
+++ b/src/entities/RequestForm.ts
@@ -6,24 +6,69 @@ export enum ServiceTypes{
   LACTATION_SUPPORT = "Lactation Support",
   PHOTOGRAPHY = "Photography",
   OTHER = "Other"
+}
 
+export enum Pronouns{
+  HE_HIM = "he/him",
+  SHE_HER = "she/her",
+  THEY_THEM = "they/them",
+  OTHER = "other",
+}
+
+export enum Sex{
+  MALE = "Male",
+  FEMALE = "Female"
+}
+
+export enum IncomeLevel{
+  FROM_0_TO_24999 = "$0 - $24,999",
+  FROM_25000_TO_44999 = "$25,000 - $44,999",
+  FROM_45000_TO_64999 = "$45,000 - $64,999",
+  FROM_65000_TO_84999 = "$65,000 - $84,999",
+  FROM_85000_TO_99999 = "$85,000 - $99,999",
+  ABOVE_100000 = "$100,000 and above"
 }
 
 export class RequestForm{
-  first_name:string; 
-  last_name:string;
-  email:string;
-  phone_number:string;
-  children_expected:number;
-  service_needed:ServiceTypes;
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone_number: string;
+  children_expected: string;
+  service_needed: ServiceTypes;
+  pronouns: Pronouns;
+  address: string;
+  city: string;
+  state: string;
+  zip_code: string;
+  health_history: string;
+  allergies: string;
+  due_date: Date;
+  hospital: string;
+  baby_sex: Sex;
+  annual_income: IncomeLevel;
+  service_specifics: string;
 
+  
   constructor(
-    first_name: string,
-    last_name: string,
-    email: string,
-    phone_number: string,
-    children_expected: number,
-    service_needed: ServiceTypes
+    first_name: string, 
+    last_name: string, 
+    email: string, 
+    phone_number: string, 
+    children_expected: string, 
+    service_needed: ServiceTypes, 
+    pronouns: Pronouns, 
+    address: string, 
+    city: string, 
+    state: string, 
+    zip_code: string, 
+    health_history: string, 
+    allergies: string, 
+    due_date: Date, 
+    hospital: string, 
+    baby_sex: Sex, 
+    annual_income: IncomeLevel,
+    service_specifics: string, 
   ){
     this.first_name = first_name
     this.last_name = last_name
@@ -31,6 +76,17 @@ export class RequestForm{
     this.phone_number = phone_number
     this.children_expected = children_expected
     this.service_needed = service_needed
+    this.pronouns = pronouns 
+    this.address = address 
+    this.city = city 
+    this.state = state 
+    this.zip_code = zip_code 
+    this.health_history = health_history 
+    this.allergies = allergies 
+    this.due_date = due_date 
+    this.hospital = hospital 
+    this.baby_sex = baby_sex 
+    this.annual_income = annual_income
+    this.service_specifics = service_specifics
   }
-
 }

--- a/src/middleware/adminMiddleware.ts
+++ b/src/middleware/adminMiddleware.ts
@@ -1,0 +1,30 @@
+import { NextFunction, Response } from 'express';
+import { AuthRequest } from 'types';
+
+const adminMiddleware = async (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    if (!req.user) {
+      res.status(401).json({ error: 'Authentication required' });
+      return;
+    }
+    
+    // TEMPORARY WAY TO CHECK IF ADMIN, SHOULD IMPLEMENT CORRECT WAY 
+    // lowkey i think this is safe but not entirely sure
+    const isAdmin = req.user.email == 'sokanacollective245@gmail.com'; //boolean check if admin, temporary
+
+    if (!isAdmin) {
+      res.status(403).json({ error: 'Admin access required' });
+      return;
+    }
+
+    next();
+  } catch (error) {
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+export default adminMiddleware;

--- a/src/repositories/RequestFormRepository.ts
+++ b/src/repositories/RequestFormRepository.ts
@@ -80,7 +80,7 @@ export class RequestFormRepository{
     async updateRequestStatus(requestId: number, status: 'pending' | 'approved' | 'rejected') {
         const { data, error } = await supabase
             .from('client_request_form')
-            .update({ status: status, created_at: new Date() })
+            .update({ status: status })
             .eq('id', requestId)
             .select()
             .single();

--- a/src/repositories/RequestFormRepository.ts
+++ b/src/repositories/RequestFormRepository.ts
@@ -3,11 +3,14 @@ import dotenv from "dotenv";
 dotenv.config()
 const supabase = createClient(process.env.SUPABASE_URL,process.env.SUPABASE_ANON_KEY) 
 
+
+
 export class RequestFormRepository{
     async saveData(formData){
         try {
+            console.log(" Attempting to insert form data:", formData);
             const {data,error } = await supabase 
-             .from('user_requests') // this will take whatever table we store this data in, not sure if we should have a seperate requests table
+             .from('requests') 
              .insert([
                 {
                     first_name: formData.first_name,
@@ -15,18 +18,34 @@ export class RequestFormRepository{
                     email: formData.email,
                     phone_number: formData.phone_number,
                     children_expected: formData.children_expected,
-                    service_needed: formData.service_needed
+                    service_needed: formData.service_needed,
+                    pronouns: formData.pronouns,
+                    address: formData.address,
+                    city: formData.city,
+                    state: formData.state,
+                    zip_code: formData.zip_code,
+                    health_history: formData.health_history,
+                    allergies: formData.allergies,
+                    due_date: formData.due_date,
+                    hospital: formData.hospital,
+                    baby_sex: formData.baby_sex,
+                    annual_income: formData.annual_income,
+                    service_specifics: formData.service_specifics,
                 }
-            ]);
+            ])
 
         if (error) {
-            throw new Error(error.message);
+            console.error("Supabase insert error:", error);
+            throw new Error("Database insertion failed: " + error.message);        
         }
 
         console.log('Form saved successfully:', data);
+        return data;
+
 
         } catch (error) {
-            console.error(error)
+            console.error(error);
+            throw error;
         }
     }
 

--- a/src/repositories/RequestFormRepository.ts
+++ b/src/repositories/RequestFormRepository.ts
@@ -3,14 +3,12 @@ import dotenv from "dotenv";
 dotenv.config()
 const supabase = createClient(process.env.SUPABASE_URL,process.env.SUPABASE_ANON_KEY) 
 
-
-
 export class RequestFormRepository{
     async saveData(formData){
         try {
             console.log(" Attempting to insert form data:", formData);
             const {data,error } = await supabase 
-             .from('requests') 
+             .from('client_request_form') 
              .insert([
                 {
                     first_name: formData.first_name,
@@ -49,4 +47,49 @@ export class RequestFormRepository{
         }
     }
 
+    async getRequestById(requestId: number) {
+        const { data, error } = await supabase
+            .from('client_request_form')
+            .select('*')
+            .eq('id', requestId)
+            .single();
+    
+        if (error) {
+            console.error("Failed to fetch request:", error);
+            throw new Error("Failed to fetch request: " + error.message);
+        }
+    
+        return data;
+    }
+    
+    async getAllPendingRequests() {
+        const { data, error } = await supabase
+            .from('client_request_form')
+            .select('*')
+            .eq('status', 'pending')
+            .order('created_at', { ascending: false });
+    
+        if (error) {
+            console.error("Failed to fetch pending requests:", error);
+            throw new Error("Failed to fetch pending requests: " + error.message);
+        }
+    
+        return data;
+    }
+    
+    async updateRequestStatus(requestId: number, status: 'pending' | 'approved' | 'rejected') {
+        const { data, error } = await supabase
+            .from('client_request_form')
+            .update({ status: status, created_at: new Date() })
+            .eq('id', requestId)
+            .select()
+            .single();
+    
+        if (error) {
+            console.error("Failed to update request status:", error);
+            throw new Error("Failed to update request status: " + error.message);
+        }
+    
+        return data;
+    }
 }

--- a/src/repositories/supabaseUserRepository.ts
+++ b/src/repositories/supabaseUserRepository.ts
@@ -109,7 +109,6 @@ export class SupabaseUserRepository implements UserRepository {
       firstname: data.firstname,
       lastname: data.lastname,
       createdAt: new Date(data.created_at || Date.now()),
-      updatedAt: new Date(data.updated_at || Date.now())
     });
   }
 }

--- a/src/routes/adminRoutes.ts
+++ b/src/routes/adminRoutes.ts
@@ -1,0 +1,20 @@
+import express, { Router } from 'express';
+import authMiddleware from '../middleware/authMiddleware';
+import { RequestApprovalController } from '../controllers/RequestApprovalController';
+
+const adminRouter: Router = express.Router();
+const requestApprovalController = new RequestApprovalController();
+
+adminRouter.get('/dashboard', authMiddleware, (req, res) => {
+  res.status(200).json({ message: "Admin dashboard data" });
+});
+
+adminRouter.get('/requests/pending', authMiddleware, (req, res) => 
+  requestApprovalController.getPendingRequests(req, res)
+);
+
+adminRouter.post('/requests/approve/:requestId', authMiddleware, (req, res) => 
+  requestApprovalController.approveRequest(req, res)
+);
+
+export default adminRouter;

--- a/src/routes/requestRoute.ts
+++ b/src/routes/requestRoute.ts
@@ -1,11 +1,23 @@
+import { RequestApprovalController } from 'controllers/RequestApprovalController';
+import { RequestFormController } from 'controllers/RequestFormController';
 import express, { Router } from 'express';
 import authMiddleware from '../middleware/authMiddleware';
-import { RequestFormController } from 'controllers/RequestFormController';
 
-const requestRouter: Router =  express.Router();
+const requestRouter: Router = express.Router();
 const requestFormController = new RequestFormController();
+const requestApprovalController = new RequestApprovalController();
 
 requestRouter.post('/requestSubmission', (req, res) => 
   requestFormController.createForm(req, res)  
 );
+
+// Admin routes - protected by auth middleware
+requestRouter.get('/pending', authMiddleware, (req, res) => 
+  requestApprovalController.getPendingRequests(req, res)
+);
+
+requestRouter.post('/approve/:requestId', authMiddleware, (req, res) => 
+  requestApprovalController.approveRequest(req, res)
+);
+
 export default requestRouter;

--- a/src/routes/requestRoute.ts
+++ b/src/routes/requestRoute.ts
@@ -1,0 +1,11 @@
+import express, { Router } from 'express';
+import authMiddleware from '../middleware/authMiddleware';
+import { RequestFormController } from 'controllers/RequestFormController';
+
+const requestRouter: Router =  express.Router();
+const requestFormController = new RequestFormController();
+
+requestRouter.post('/requestSubmission', (req, res) => 
+  requestFormController.createForm(req, res)  
+);
+export default requestRouter;

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,9 +2,10 @@ import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import express, { Express, NextFunction, Request, Response } from 'express';
+import emailRoutes from 'routes/EmailRoutes';
+import adminRoutes from 'routes/adminRoutes';
 import authRoutes from 'routes/authRoutes';
 import requestRouter from 'routes/requestRoute';
-import emailRoutes from 'routes/EmailRoutes';
 
 dotenv.config();
 
@@ -59,6 +60,7 @@ app.use('/email', emailRoutes);
 
 app.use('/requestService', requestRouter);
 
+app.use('/admin', adminRoutes); 
 
 app.get('/health', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import express, { Express, NextFunction, Request, Response } from 'express';
 import authRoutes from 'routes/authRoutes';
+import requestRouter from 'routes/requestRoute';
 
 dotenv.config();
 
@@ -53,6 +54,9 @@ app.use((req, res, next) => {
 });
 
 app.use('/auth', authRoutes);
+
+app.use('/requestService', requestRouter);
+
 
 app.get('/health', (_req: Request, res: Response) => {
   res.status(200).json({ status: 'ok' });

--- a/src/services/RequestApprovalService.ts
+++ b/src/services/RequestApprovalService.ts
@@ -19,7 +19,7 @@ export class RequestApprovalService {
     await this.requestRepository.updateRequestStatus(requestId, 'approved');
 
     const token = crypto.randomUUID();
-    const signupUrl = `${signupBaseUrl}?token=${token}&email=${request.email}`;
+    const signupUrl = signupBaseUrl;
 
     // 4. Send approval email
     await this.emailService.sendClientApprovalEmail(

--- a/src/services/RequestApprovalService.ts
+++ b/src/services/RequestApprovalService.ts
@@ -1,0 +1,31 @@
+import { RequestFormRepository } from '../repositories/RequestFormRepository';
+import { NodemailerService } from './EmailService';
+
+export class RequestApprovalService {
+  private emailService: NodemailerService;
+  private requestRepository: RequestFormRepository;
+
+  constructor() {
+    this.emailService = new NodemailerService();
+    this.requestRepository = new RequestFormRepository();
+  }
+
+  async approveRequest(requestId: number, signupBaseUrl: string): Promise<void> {
+    const request = await this.requestRepository.getRequestById(requestId);
+    if (!request) {
+      throw new Error('Request not found');
+    }
+
+    await this.requestRepository.updateRequestStatus(requestId, 'approved');
+
+    const token = crypto.randomUUID();
+    const signupUrl = `${signupBaseUrl}?token=${token}&email=${request.email}`;
+
+    // 4. Send approval email
+    await this.emailService.sendClientApprovalEmail(
+      request.email,
+      `${request.first_name} ${request.last_name}`,
+      signupUrl
+    );
+  }
+}

--- a/src/services/RequestFormService.ts
+++ b/src/services/RequestFormService.ts
@@ -1,32 +1,70 @@
-import {RequestForm} from "../Entities/RequestForm"
-import { RequestFormRepository } from "../Repositories/RequestFormRepository"
+import { RequestForm, ServiceTypes, Pronouns, Sex, IncomeLevel } from "../entities/RequestForm";
+import { RequestFormRepository } from "../repositories/RequestFormRepository";
+import { ValidationError } from "../domainErrors";
 
-export class RequestFormService{
+export class RequestFormService {
+  private repository: RequestFormRepository;
 
-    private repository : RequestFormRepository
+  constructor() {
+    this.repository = new RequestFormRepository();
+  }
 
-
-    constructor(){
-        this.repository = new RequestFormRepository();
+  async newForm(formData: {
+    first_name: string;
+    last_name: string;
+    email: string;
+    phone_number: string;
+    children_expected: string;
+    service_needed: ServiceTypes;
+    pronouns: Pronouns;
+    address: string;
+    city: string;
+    state: string;
+    zip_code: string;
+    health_history: string;
+    allergies: string;
+    due_date: Date;
+    hospital: string;
+    baby_sex: Sex;
+    annual_income: IncomeLevel;
+    service_specifics: string;
+  }): Promise<RequestForm> {
+    if (!formData.first_name || !formData.last_name || !formData.service_needed) {
+      throw new ValidationError("Missing required fields: name and service type");
+    }
+    
+    if (!formData.email || !formData.email.includes('@')) {
+      throw new ValidationError("Valid email is required");
+    }
+    
+    if (!formData.phone_number) {
+      throw new ValidationError("Phone number is required");
     }
 
-    async newForm(formData){
-        if (!formData.first_name || !formData.last_name || !formData.service_needed){
-            throw Error
-        }
-        if (!formData.email || !formData.email.includes('@')){
-            throw Error
-        }
-    
-
-    const finalForm = new RequestForm(
-        formData.first_name,
-        formData.last_name,
-        formData.email,
-        formData.service_needed,
-        formData.phone_number,
-        formData.address
+    const requestForm = new RequestForm(
+      formData.first_name,
+      formData.last_name,
+      formData.email,
+      formData.phone_number,
+      formData.children_expected,
+      formData.service_needed,
+      formData.pronouns, 
+      formData.address, 
+      formData.city, 
+      formData.state, 
+      formData.zip_code, 
+      formData.health_history, 
+      formData.allergies, 
+      formData.due_date, 
+      formData.hospital, 
+      formData.baby_sex, 
+      formData.annual_income,
+      formData.service_specifics,
     );
-}
 
+    // Save to repository
+    await this.repository.saveData(requestForm);
+    
+    return requestForm;
+  }
 }

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -1,5 +1,5 @@
 import nodemailer from 'nodemailer';
-import { EmailService } from './interface/EmailServiceInterface';
+import { EmailService } from './interface/emailServiceInterface';
 
 export class NodemailerService implements EmailService {
   private transporter: nodemailer.Transporter;

--- a/test-approval-flow.ts
+++ b/test-approval-flow.ts
@@ -1,0 +1,36 @@
+import dotenv from 'dotenv';
+import { RequestFormRepository } from './src/repositories/RequestFormRepository';
+import { RequestApprovalService } from './src/services/RequestApprovalService';
+
+dotenv.config();
+
+async function testApprovalFlow() {
+  try {
+    const repository = new RequestFormRepository();
+    
+    // 1. Get all pending requests
+    console.log('Fetching pending requests...');
+    const pendingRequests = await repository.getAllPendingRequests();
+    console.log(`Found ${pendingRequests.length} pending requests`);
+    
+    if (pendingRequests.length > 0) {
+      const requestToApprove = pendingRequests[0];
+      console.log(`Testing approval for request ID ${requestToApprove.id}`);
+      
+      // 2. Approve the first pending request
+      const approvalService = new RequestApprovalService();
+      await approvalService.approveRequest(
+        requestToApprove.id,
+        'http://localhost:3001/signup'
+      );
+      
+      console.log('Approval process completed successfully');
+    } else {
+      console.log('No pending requests found to test');
+    }
+  } catch (error) {
+    console.error('Test failed:', error);
+  }
+}
+
+testApprovalFlow();


### PR DESCRIPTION
Background: only Admins can approve Requests to be clients, which are populated on Supabase and marked as "pending". After Admins approve, on Supabase the `status` field becomes "approved". The user is sent an email notifying approval.

I've merged Daniel's branch and my branch together, and I've added a few files for the routing and API calls for admin handling logic. 

I will say I'd like this to be reviewed (by Ethan probably): in `adminMiddleware.ts`, for the moment we verify someone is an admin by confirming their email is the shared one we created for this project.

 ```
// TEMPORARY WAY TO CHECK IF ADMIN, SHOULD IMPLEMENT CORRECT WAY 
// lowkey i think this is safe but not entirely sure
const isAdmin = req.user.email == 'sokanacollective245@gmail.com'; //boolean check if admin, temporary
```

There isn't a lot of true admin authentication for now. This is primarily for demo purposes.