### PR TITLE
Secure backend production logging for SEC-01

### DIFF
--- a/phi-broker/src/controllers/phiController.ts
+++ b/phi-broker/src/controllers/phiController.ts
@@ -3,9 +3,9 @@
  *
  * HIPAA COMPLIANCE:
  * - PHI values are NEVER logged
- * - Only metadata is logged (role, user_id, client_id, authorized, latency)
+ * - Only correlation, outcome, count, and latency metadata is logged
  * - Unauthorized requests return empty data (not error)
- * - Error logs: error.name, message, pg code/constraint/table/column only — no body, no PHI
+ * - Error logs use fixed internal categories and never serialize errors
  */
 
 import { Request, Response } from 'express';
@@ -51,24 +51,18 @@ function isAuthorized(requester: PhiRequest['requester'], clientId: string): boo
 }
 
 /**
- * HIPAA-safe error log: error.name, message, optional pg fields; client_id, user_id, role, authorized, latency_ms, request_id.
- * Never log request body or PHI values.
+ * HIPAA-safe error log: fixed category, correlation ID, and latency only.
  */
 function logPhiError(
   requestId: string | undefined,
   error: unknown,
-  meta: { client_id?: string; user_id?: string; role?: string; authorized?: boolean; latency_ms: number }
+  meta: { latency_ms: number }
 ): void {
-  const err = error instanceof Error ? error : new Error(String(error));
-  const pg = err as { code?: string; constraint?: string; table?: string; column?: string };
+  void error;
   console.error('[PHI] Error processing request', {
     request_id: requestId,
-    error_name: err.name,
-    error_message: err.message,
-    ...(pg.code && { pg_code: pg.code }),
-    ...(pg.constraint && { pg_constraint: pg.constraint }),
-    ...(pg.table && { pg_table: pg.table }),
-    ...(pg.column && { pg_column: pg.column }),
+    error_code: 'PHI_OPERATION_FAILED',
+    retryable: false,
     ...meta,
   });
 }
@@ -109,9 +103,6 @@ export async function getClientPhi(req: Request, res: Response): Promise<void> {
 
     console.log('[PHI] Request', {
       request_id: requestId,
-      client_id,
-      user_id: requester.user_id,
-      role: requester.role,
       authorized,
       latency_ms: Date.now() - startTime,
     });
@@ -131,8 +122,6 @@ export async function getClientPhi(req: Request, res: Response): Promise<void> {
     const totalLatency = Date.now() - startTime;
     console.log('[PHI] Response', {
       request_id: requestId,
-      client_id,
-      user_id: requester.user_id,
       authorized: true,
       field_count: Object.keys(result.data).length,
       latency_ms: totalLatency,
@@ -142,10 +131,6 @@ export async function getClientPhi(req: Request, res: Response): Promise<void> {
   } catch (error) {
     const latency = Date.now() - startTime;
     logPhiError(requestId, error, {
-      client_id: (req.body as PhiRequest)?.client_id,
-      user_id: (req.body as PhiRequest)?.requester?.user_id,
-      role: (req.body as PhiRequest)?.requester?.role,
-      authorized: (req.body as PhiRequest) ? isAuthorized((req.body as PhiRequest).requester, (req.body as PhiRequest).client_id) : undefined,
       latency_ms: latency,
     });
     if (!res.headersSent) {
@@ -228,23 +213,16 @@ export async function updateClientPhi(req: Request, res: Response): Promise<void
     if (requester.role !== 'admin') {
       console.log('[PHI] Update denied (not admin)', {
         request_id: requestId,
-        client_id,
-        user_id: requester.user_id,
-        role: requester.role,
         latency_ms: Date.now() - startTime,
       });
       res.status(403).json(ResponseBuilder.error('Not authorized to update PHI', 'FORBIDDEN', requestId));
       return;
     }
 
-    // HIPAA: log metadata only — keys are fine, values NEVER
+    // HIPAA: log count only; field names and values are not logged.
     console.log('[PHI] Update request', {
       request_id: requestId,
-      client_id,
-      user_id: requester.user_id,
-      role: requester.role,
       field_count: Object.keys(fields).length,
-      field_keys: Object.keys(fields),
     });
 
     // ── Perform update ──
@@ -253,10 +231,8 @@ export async function updateClientPhi(req: Request, res: Response): Promise<void
     const totalLatency = Date.now() - startTime;
     console.log('[PHI] Update response', {
       request_id: requestId,
-      client_id,
-      user_id: requester.user_id,
       updated: result.updated,
-      updated_keys: result.updated_keys,
+      updated_count: result.updated_keys.length,
       latency_ms: totalLatency,
     });
 
@@ -264,9 +240,6 @@ export async function updateClientPhi(req: Request, res: Response): Promise<void
   } catch (error) {
     const latency = Date.now() - startTime;
     logPhiError(requestId, error, {
-      client_id: (req.body as any)?.client_id,
-      user_id: (req.body as any)?.requester?.user_id,
-      role: (req.body as any)?.requester?.role,
       latency_ms: latency,
     });
     if (!res.headersSent) {

--- a/phi-broker/src/db/pool.ts
+++ b/phi-broker/src/db/pool.ts
@@ -54,7 +54,7 @@ export function getPool(): Pool {
     // Do NOT log err object which may contain connection info
   });
 
-  console.log('[DB] Pool initialized', { host: host.substring(0, 10) + '...', port, ssl });
+  console.log('[DB] Pool initialized', { port, ssl: Boolean(ssl) });
 
   return pool;
 }

--- a/phi-broker/src/index.ts
+++ b/phi-broker/src/index.ts
@@ -56,8 +56,7 @@ function phiClientHandler(req: Request, res: Response, next: NextFunction): void
     // HIPAA-safe: no PHI, no request body
     console.error('[Server] Unhandled error in PHI handler', {
       request_id: requestId,
-      error_name: err instanceof Error ? err.name : 'Unknown',
-      error_message: err instanceof Error ? err.message : String(err),
+      error_code: 'PHI_HANDLER_FAILED',
     });
     if (!res.headersSent) {
       res.status(500).json(ResponseBuilder.error('Internal server error', 'INTERNAL_ERROR', requestId));
@@ -74,8 +73,7 @@ function phiUpdateHandler(req: Request, res: Response, next: NextFunction): void
     const requestId = reqWithId.requestId;
     console.error('[Server] Unhandled error in PHI update handler', {
       request_id: requestId,
-      error_name: err instanceof Error ? err.name : 'Unknown',
-      error_message: err instanceof Error ? err.message : String(err),
+      error_code: 'PHI_UPDATE_FAILED',
     });
     if (!res.headersSent) {
       res.status(500).json(ResponseBuilder.error('Internal server error', 'INTERNAL_ERROR', requestId));
@@ -96,8 +94,7 @@ app.use((err: Error, req: Request, res: Response, _next: express.NextFunction) =
   const requestId = reqWithId.requestId;
   console.error('[Server] Unhandled error', {
     request_id: requestId,
-    error_name: err.name,
-    error_message: err.message,
+    error_code: 'PHI_BROKER_FAILURE',
   });
   if (!res.headersSent) {
     res.status(500).json(ResponseBuilder.error('Internal server error', 'INTERNAL_ERROR', requestId));

--- a/src/__tests__/securityLogging.test.ts
+++ b/src/__tests__/securityLogging.test.ts
@@ -1,0 +1,76 @@
+import express from 'express';
+import request from 'supertest';
+
+import {
+  createSafeRequestLogger,
+  installProductionConsoleGuard,
+  toSafeProviderError,
+} from '../common/utils/safeLogging';
+
+const sensitiveValues = [
+  'Jane Client', 'jane@example.test', '2030-04-17', 'INS-998877',
+  'birth_preferences=private', 'oauth-code-secret', 'oauth-state-secret',
+  'access-token-secret', 'refresh-token-secret',
+  'https://payments.example.test/pay/private-link', 'signnow-private-field',
+  'Bearer authorization-secret', 'session=private-cookie', 'diagnosis=private-phi',
+];
+
+describe('SEC-01-BE safe logging', () => {
+  it('HTTP logging emits only allowlisted request metadata', async () => {
+    const entries: unknown[][] = [];
+    const fakeLogger = { info: (...args: unknown[]) => entries.push(args) } as any;
+    const app = express();
+    app.use(express.json());
+    app.use(createSafeRequestLogger(fakeLogger));
+    app.post('/clients/:clientId/contracts', (_req, res) => {
+      res.status(202).json({ ok: true });
+    });
+
+    await request(app)
+      .post('/clients/private-client-id/contracts?oauth-code=oauth-code-secret')
+      .set('authorization', 'Bearer authorization-secret')
+      .set('cookie', 'session=private-cookie')
+      .set('x-request-id', 'corr_SEC01')
+      .send({ name: 'Jane Client', email: 'jane@example.test', phi: 'diagnosis=private-phi' })
+      .expect(202);
+
+    const output = JSON.stringify(entries);
+    sensitiveValues.forEach((value) => expect(output).not.toContain(value));
+    expect(entries[0][0]).toEqual(expect.objectContaining({
+      service: 'backend-http', correlationId: 'corr_SEC01', method: 'POST',
+      route: '/clients/:clientId/contracts', status: 202,
+    }));
+  });
+
+  it.each([
+    ['supabase', 'authenticate', 401],
+    ['quickbooks', 'oauth_callback', 502],
+    ['signnow', 'send_contract', 429],
+    ['stripe', 'create_payment', 503],
+  ])('normalizes %s failures without provider payloads', (service, operation, status) => {
+    const payload = Object.fromEntries(sensitiveValues.map((value, index) => [`secret${index}`, value]));
+    const error = { message: sensitiveValues.join(' '), config: payload, response: { status, data: payload } };
+    const safe = toSafeProviderError(service, operation, error, 'corr_SEC01');
+    const output = JSON.stringify(safe);
+
+    sensitiveValues.forEach((value) => expect(output).not.toContain(value));
+    expect(safe).toEqual(expect.objectContaining({
+      service, operation, status, correlationId: 'corr_SEC01',
+      errorCode: `PROVIDER_HTTP_${status}`,
+    }));
+  });
+
+  it('suppresses legacy console arguments in production', () => {
+    const originalEnv = process.env.NODE_ENV;
+    const originals = { log: console.log, info: console.info, warn: console.warn, error: console.error, debug: console.debug, dir: console.dir };
+    try {
+      process.env.NODE_ENV = 'production';
+      installProductionConsoleGuard();
+      sensitiveValues.forEach((value) => console.error(value));
+      expect(console.error).not.toBe(originals.error);
+    } finally {
+      process.env.NODE_ENV = originalEnv;
+      Object.assign(console, originals);
+    }
+  });
+});

--- a/src/common/utils/logger.ts
+++ b/src/common/utils/logger.ts
@@ -33,6 +33,27 @@ const baseOptions: pino.LoggerOptions = {
       return { severity: label.toUpperCase() };
     },
   },
+  hooks: {
+    logMethod(args, method) {
+      const allowed = new Set([
+        'service', 'module', 'operation', 'correlationId', 'method', 'route',
+        'status', 'durationMs', 'errorCode', 'retryable', 'severity', 'context',
+        'count', 'source', 'partsCount', 'port', 'host',
+      ]);
+      const first = args[0];
+      if (first && typeof first === 'object') {
+        const safe = Object.fromEntries(
+          Object.entries(first as Record<string, unknown>).filter(([key, value]) =>
+            allowed.has(key) && ['string', 'number', 'boolean'].includes(typeof value)
+          )
+        );
+        method.apply(this, [safe, ...args.slice(1)]);
+        return;
+      }
+      // A bare Error or dynamic object has no approved diagnostic fields.
+      method.apply(this, args);
+    },
+  },
   transport: isProd
     ? undefined
     : {

--- a/src/common/utils/safeLogging.ts
+++ b/src/common/utils/safeLogging.ts
@@ -1,0 +1,86 @@
+import { NextFunction, Request, RequestHandler, Response } from 'express';
+import { randomUUID } from 'node:crypto';
+import { Logger } from 'pino';
+
+export type SafeProviderError = {
+  service: string;
+  operation: string;
+  errorCode: string;
+  status?: number;
+  correlationId?: string;
+  retryable: boolean;
+};
+
+const safeStatus = (error: unknown): number | undefined => {
+  const value = (error as { response?: { status?: unknown }; status?: unknown }) || {};
+  const candidate = value.response?.status ?? value.status;
+  return typeof candidate === 'number' && candidate >= 400 && candidate <= 599
+    ? candidate
+    : undefined;
+};
+
+export const toSafeProviderError = (
+  service: string,
+  operation: string,
+  error: unknown,
+  correlationId?: string,
+): SafeProviderError => {
+  const status = safeStatus(error);
+  return {
+    service,
+    operation,
+    errorCode: status ? `PROVIDER_HTTP_${status}` : 'PROVIDER_FAILURE',
+    ...(status ? { status } : {}),
+    ...(correlationId ? { correlationId } : {}),
+    retryable: status === 408 || status === 429 || (status !== undefined && status >= 500),
+  };
+};
+
+const safeRequestId = (value: unknown): string =>
+  typeof value === 'string' && /^[A-Za-z0-9_-]{1,128}$/.test(value) ? value : randomUUID();
+
+const generalizedRoute = (req: Request): string => {
+  const routePath = req.route?.path;
+  if (typeof routePath === 'string') return `${req.baseUrl || ''}${routePath}` || '/';
+  return 'unmatched';
+};
+
+/** Request logging is intentionally implemented as an allowlist, not serializers/redaction. */
+export const createSafeRequestLogger = (requestLogger: Logger): RequestHandler =>
+  (req: Request, res: Response, next: NextFunction): void => {
+    const startedAt = process.hrtime.bigint();
+    const correlationId = safeRequestId(req.get('x-request-id'));
+    res.setHeader('x-request-id', correlationId);
+
+    res.once('finish', () => {
+      const durationMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+      requestLogger.info({
+        service: 'backend-http',
+        correlationId,
+        method: req.method,
+        route: generalizedRoute(req),
+        status: res.statusCode,
+        durationMs: Math.round(durationMs * 100) / 100,
+      }, 'HTTP request completed');
+    });
+    next();
+  };
+
+/**
+ * Legacy console calls are not structured enough to prove their arguments are safe.
+ * Production suppresses them; approved operational logging goes through the logger.
+ */
+export const installProductionConsoleGuard = (): void => {
+  if (process.env.NODE_ENV !== 'production') return;
+  const noop = (): void => undefined;
+  console.log = noop;
+  console.info = noop;
+  console.warn = noop;
+  console.error = noop;
+  console.debug = noop;
+  console.dir = noop as typeof console.dir;
+};
+
+// This module is imported before route/service modules in the server bootstrap, so
+// production cannot leak from module-scope constructors during application startup.
+installProductionConsoleGuard();

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -19,6 +19,7 @@ import {
 } from '../types';
 import { AuthUseCase } from '../usecase/authUseCase.js';
 import { logger } from '../common/utils/logger';
+import { toSafeProviderError } from '../common/utils/safeLogging';
 
 
 export class AuthController {
@@ -115,8 +116,6 @@ export class AuthController {
       if (tokenParts.length !== 3) {
         logger.error({
           context: 'AuthController.getMe',
-          tokenLength: token.length,
-          tokenPreview: token.substring(0, 50) + '...',
           partsCount: tokenParts.length,
         }, 'Invalid JWT format');
         res.status(401).json({ error: 'Invalid token format: JWT must have 3 parts', details: `Received ${tokenParts.length} parts, expected 3` })
@@ -266,7 +265,7 @@ export class AuthController {
     res: Response
   ): Promise<void> {
     try {
-      logger.info({ context: 'AuthController.handleOAuthCallback', query: req.query }, 'OAuth callback received');
+      logger.info({ service: 'supabase', operation: 'oauth_callback' }, 'OAuth callback received');
       const code = req.query.code as string;
 
       // call useCase to retrieve current session and user
@@ -320,7 +319,7 @@ export class AuthController {
 
       res.json({ success: true , user: user.toJSON()});
     } catch (handleTokenError) {
-      logger.error({ err: handleTokenError, context: 'AuthController.handleToken' }, 'Handle token failed');
+      logger.error(toSafeProviderError('supabase', 'handle_token', handleTokenError), 'Handle token failed');
       // const error = this.handleError(handleTokenError, res);
       // res.status(error.status).json({ error: error.message})
     }
@@ -415,7 +414,7 @@ export class AuthController {
     error: Error,
     res: Response
   ): { status: number, message: string } {
-    logger.error({ err: error, context: 'AuthController.handleError' }, 'Error handling request');
+    logger.error(toSafeProviderError('supabase', 'auth_request', error), 'Error handling request');
 
     if (error instanceof ValidationError) {
       return { status: 400, message: error.message};

--- a/src/controllers/quickbooksController.ts
+++ b/src/controllers/quickbooksController.ts
@@ -15,6 +15,8 @@ import { getQuickBooksCompanyInfo } from '../services/customer/getQuickBooksComp
 import { refreshCustomerQuickBooksSyncStatus } from '../services/customer/refreshCustomerQuickBooksSyncStatus';
 import { listInvoicesFromCloudSql } from '../repositories/cloudSqlInvoiceRepository';
 import { getQuickBooksConnectionHealth } from '../utils/tokenUtils';
+import { logger } from '../common/utils/logger';
+import { toSafeProviderError } from '../common/utils/safeLogging';
 // Ensure you have SUPABASE_JWT_SECRET in your env
 const JWT_SECRET = process.env.SUPABASE_JWT_SECRET!
 
@@ -53,7 +55,7 @@ export const quickBooksAuthUrl: RequestHandler = (_req, res, next) => {
     console.log('✅ [QB Auth] Generated auth URL successfully');
     res.json({ url });
   } catch (err: any) {
-    console.error('❌ [QB Auth] Error generating auth URL:', err);
+    logger.error(toSafeProviderError('quickbooks', 'generate_consent_url', err), 'QuickBooks operation failed');
     res.status(500).json({
       error: 'Could not fetch QuickBooks auth URL',
       details: err?.message || 'Unknown error occurred'
@@ -80,7 +82,7 @@ export const connectQuickBooks: RequestHandler = (req, res, next) => {
 export const handleQuickBooksCallback: RequestHandler = async (req, res, next) => {
   try {
     const fullUrl = `${req.protocol}://${req.get('host')}${req.originalUrl}`
-    console.log('🔄 [QB Callback] Processing OAuth callback:', fullUrl);
+    logger.info({ service: 'quickbooks', operation: 'oauth_callback' }, 'QuickBooks callback received');
 
     await handleAuthCallback(fullUrl)
     console.log('✅ [QB Callback] QuickBooks connected successfully');
@@ -89,13 +91,12 @@ export const handleQuickBooksCallback: RequestHandler = async (req, res, next) =
     const frontendUrl = process.env.FRONTEND_URL || process.env.FRONTEND_URL_DEV || 'http://localhost:3001';
     const successPath = process.env.QUICKBOOKS_SUCCESS_REDIRECT_PATH || '/integrations/quickbooks';
     const redirectUrl = `${frontendUrl}${successPath.startsWith('/') ? successPath : `/${successPath}`}?quickbooks=connected`;
-    console.log('🔀 [QB Callback] Redirecting to:', redirectUrl);
 
     // Use HTTP redirect so the browser navigates immediately (no reliance on JavaScript)
     res.redirect(302, redirectUrl);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Connection failed';
-    console.error('❌ [QB Callback] Error processing callback:', err);
+    logger.error(toSafeProviderError('quickbooks', 'oauth_callback', err), 'QuickBooks operation failed');
     const frontendUrl = process.env.FRONTEND_URL || process.env.FRONTEND_URL_DEV || 'http://localhost:3001';
     const errorPath = process.env.QUICKBOOKS_SUCCESS_REDIRECT_PATH || '/integrations/quickbooks';
     const errorRedirectUrl = `${frontendUrl}${errorPath.startsWith('/') ? errorPath : `/${errorPath}`}?quickbooks=error&message=${encodeURIComponent(message)}`;
@@ -165,11 +166,11 @@ export const quickBooksStatus: RequestHandler = async (req, res, next) => {
       const company = await getQuickBooksCompanyInfo();
       res.json({ connected: true, company });
     } catch (companyError) {
-      console.warn('⚠️ [QB Status] Connected, but company details could not be loaded:', companyError);
+      logger.warn(toSafeProviderError('quickbooks', 'company_details', companyError), 'QuickBooks operation failed');
       res.json({ connected: true, company: null, companyDetailsUnavailable: true });
     }
   } catch (err) {
-    console.error('❌ [QB Status] Error checking status:', err);
+    logger.error(toSafeProviderError('quickbooks', 'connection_status', err), 'QuickBooks operation failed');
     next(err);
   }
 }
@@ -217,7 +218,7 @@ export const getQuickBooksCustomers: RequestHandler = async (req, res, next) => 
     console.log(`✅ [QB Customers] Returning ${customers.length} customers`);
     res.json(customers);
   } catch (err: any) {
-    console.error('❌ [QB Customers] Error fetching customers:', err);
+    logger.error(toSafeProviderError('quickbooks', 'list_customers', err), 'QuickBooks operation failed');
     res.status(500).json({
       error: 'Failed to fetch customers from QuickBooks',
       message: err.message || 'Unknown error'

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,6 @@ import express, { Express, NextFunction, Request, Response } from 'express';
 import helmet from 'helmet';
 
 import cookieParser from 'cookie-parser';
-import pinoHttp from 'pino-http';
 
 import {
   FEATURE_QUICKBOOKS,
@@ -13,6 +12,7 @@ import {
   getAllowedOrigins,
 } from './config/env';
 import { logger } from './common/utils/logger';
+import { createSafeRequestLogger, installProductionConsoleGuard } from './common/utils/safeLogging';
 import emailRoutes from './routes/EmailRoutes';
 import authRoutes from './routes/authRoutes';
 import adminRoutes from './routes/adminRoutes';
@@ -33,6 +33,8 @@ import userRoutes from './routes/specificUserRoutes';
 import { authController } from './index';
 
 const app: Express = express();
+
+installProductionConsoleGuard();
 
 app.disable('x-powered-by');
 app.use(helmet());
@@ -64,49 +66,7 @@ app.use(cookieParser());
 
 app.use(express.json());
 
-const httpLogger = pinoHttp({
-  logger,
-  redact: {
-    paths: [
-      'req.headers.cookie',
-      'req.headers.authorization',
-      'req.headers["x-session-token"]',
-      'req.body.email',
-      'req.body.password',
-      'req.body.session_token',
-      'req.body.token',
-      'req.body.intuit_token',
-      'req.body.cardToken',
-      'req.body.card.number',
-      'req.body.card.cvc',
-      'req.body.card.expMonth',
-      'req.body.card.expYear',
-      'req.body.address',
-      'req.body.ssn',
-      'req.body.phone',
-      'req.body.health_history',
-      'req.body.dob',
-      'req.body.*.email',
-      'req.body.*.*.email',
-      'res.body.session_token',
-    ],
-    censor: '[PHI_REDACTED]',
-  },
-  serializers: {
-    req(req) {
-      return {
-        method: req.method,
-        url: req.url,
-        headers: req.headers,
-        body: req.body,
-      };
-    },
-    res(res) {
-      return { statusCode: res.statusCode };
-    },
-  },
-});
-app.use(httpLogger);
+app.use(createSafeRequestLogger(logger));
 
 // normalize duplicate slashes
 app.use((req, _res, next) => {


### PR DESCRIPTION
## What changed

- replaced request serialization with strict allowlisted HTTP telemetry
- normalized Supabase and QuickBooks provider failures into safe diagnostic metadata
- removed identifying and raw-error fields from PHI Broker logs
- added production containment for legacy console diagnostics
- added focused regression tests covering PHI, OAuth secrets, tokens, cookies, authorization headers, payment links, and provider payloads

## Why

SEC-01-BE requires production logging to exclude PHI, credentials, OAuth information, payment links, and provider payloads while retaining safe operational diagnostics.

## Impact

Logging and observability output are hardened. Authentication, authorization, route behavior, billing workflows, provider workflows, schemas, and infrastructure are unchanged.

## Validation

- main TypeScript no-emit compilation passed
- PHI Broker TypeScript no-emit compilation passed
- SEC-01 security tests: 6/6 passed
- relevant suites: 12/13 passed, 93/94 tests passed
- full suite: 37/38 passed, 299/300 tests passed
- diff checks passed

The sole failure is the known pre-existing QuickBooks customer-sync mock failure: findCustomerInQuickBooksById is not a function.