### PR TITLE
SEC-02: contain exposed SignNow credential

### DIFF
--- a/docs/SEC-02_SIGNNOW_CREDENTIAL_CONTAINMENT.md
+++ b/docs/SEC-02_SIGNNOW_CREDENTIAL_CONTAINMENT.md
@@ -1,0 +1,27 @@
+# SEC-02 — Exposed SignNow Credential Containment
+
+Status: Source containment implemented locally; credential-owner confirmation and rotation pending.
+
+## Finding
+
+A credential-shaped value was embedded in `src/routes/pdfContractRoutes.ts` and supplied to the PDF contract processing workflow as a SignNow bearer token. The affected boundary is the mounted `/api/pdf-contract` router. The value is intentionally omitted from this record.
+
+Git history shows the reference was introduced in commit `a003d33b1add2c2defc3e1f8ad190b0fb61ca15d` on 2025-11-10 and persisted in later commits. Removing it from the current source does not remove it from repository history.
+
+## Local containment
+
+- Removed the embedded value from current source.
+- Required runtime injection through `SIGNNOW_ACCESS_TOKEN`; missing configuration fails closed with HTTP 503.
+- Required authentication and the admin role for the PDF-contract router.
+- Disabled the PDF-contract test workflow in production.
+- Added regression coverage for unauthenticated 401, unauthorized 403, and absence of a long embedded token literal.
+
+## Required external actions
+
+- An authorized SignNow account owner must determine whether the historical credential is or was active.
+- If real, revoke or rotate it and assess provider audit activity from the exposure window.
+- Store any replacement in Google Secret Manager during the authorized Cloud Run configuration phase.
+- Confirm staging and production revisions inject the replacement without exposing its value.
+- Add repository secret scanning to release checks and decide whether history rewriting is necessary after rotation.
+
+No credential was tested, copied, rotated, revoked, or deployed during this work.

--- a/src/__tests__/pdfContractAuthorization.test.ts
+++ b/src/__tests__/pdfContractAuthorization.test.ts
@@ -1,0 +1,58 @@
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../middleware/authMiddleware', () => ({
+  __esModule: true,
+  default: (req: any, res: any, next: any) => {
+    const role = req.get('x-test-role');
+    if (!role) {
+      res.status(401).json({ error: 'No session token provided' });
+      return;
+    }
+    req.user = { id: 'synthetic-user', email: 'synthetic@example.test', role };
+    next();
+  },
+}));
+
+jest.mock('../utils/pdfContractProcessor', () => ({
+  getAvailableContractTemplates: jest.fn(() => ['labor_support_v1']),
+  processContractWithPdfTemplate: jest.fn(),
+  validateContractDataForTemplate: jest.fn(() => ({ valid: true, missingFields: [] })),
+}));
+
+import pdfContractRoutes from '../routes/pdfContractRoutes';
+
+describe('PDF contract authorization and credential containment', () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/pdf-contract', pdfContractRoutes);
+
+  it('rejects unauthenticated operational requests', async () => {
+    await request(app).post('/api/pdf-contract/process').send({}).expect(401);
+  });
+
+  it('rejects authenticated non-admin users', async () => {
+    await request(app)
+      .post('/api/pdf-contract/process')
+      .set('x-test-role', 'client')
+      .send({})
+      .expect(403);
+  });
+
+  it('allows an admin to reach request validation', async () => {
+    await request(app)
+      .post('/api/pdf-contract/process')
+      .set('x-test-role', 'admin')
+      .send({})
+      .expect(400);
+  });
+
+  it('contains no embedded SignNow access-token literal', () => {
+    const source = require('node:fs').readFileSync(
+      require.resolve('../routes/pdfContractRoutes'),
+      'utf8'
+    );
+    expect(source).toContain('SIGNNOW_ACCESS_TOKEN');
+    expect(source).not.toMatch(/["'][A-Za-z0-9._-]{40,}["']/);
+  });
+});

--- a/src/routes/pdfContractRoutes.ts
+++ b/src/routes/pdfContractRoutes.ts
@@ -1,5 +1,9 @@
 import express, { Request, Response } from 'express';
 
+import authMiddleware from '../middleware/authMiddleware';
+import authorizeRoles from '../middleware/authorizeRoles';
+import { IS_PRODUCTION } from '../config/env';
+
 import {
   getAvailableContractTemplates,
   processContractWithPdfTemplate,
@@ -7,6 +11,16 @@ import {
 } from '../utils/pdfContractProcessor';
 
 const router = express.Router();
+
+router.use(
+  authMiddleware,
+  (req, res, next) => authorizeRoles(req, res, next, ['admin'])
+);
+
+const getSignNowAccessToken = (): string | undefined => {
+  const token = process.env.SIGNNOW_ACCESS_TOKEN;
+  return typeof token === 'string' && token.trim() ? token.trim() : undefined;
+};
 
 interface PdfContractRequest extends Request {
   body: {
@@ -68,9 +82,14 @@ router.post(
         return;
       }
 
-      // For now, we'll use a placeholder token. In production, you'd get this from authentication
-      const signNowToken =
-        '42d2a44df392aa3418c4e4486316dd2429b27e7b690834c68cd0e407144';
+      const signNowToken = getSignNowAccessToken();
+      if (!signNowToken) {
+        res.status(503).json({
+          success: false,
+          error: 'Contract signing provider is unavailable',
+        });
+        return;
+      }
 
       // Process the contract
       const result = await processContractWithPdfTemplate(
@@ -167,6 +186,11 @@ router.post('/validate', async (req: Request, res: Response): Promise<void> => {
  */
 router.post('/test', async (req: Request, res: Response): Promise<void> => {
   try {
+    if (IS_PRODUCTION) {
+      res.status(404).json({ success: false, error: 'Not found' });
+      return;
+    }
+
     const { templateKey = 'labor_support_v1' } = req.body;
 
     // Sample contract data
@@ -182,9 +206,14 @@ router.post('/test', async (req: Request, res: Response): Promise<void> => {
       client_signed_date: new Date().toLocaleDateString(),
     };
 
-    // For testing, we'll use a placeholder token
-    const signNowToken =
-      '42d2a44df392aa3418c4e4486316dd2429b27e7b690834c68cd0e407144';
+    const signNowToken = getSignNowAccessToken();
+    if (!signNowToken) {
+      res.status(503).json({
+        success: false,
+        error: 'Contract signing provider is unavailable',
+      });
+      return;
+    }
 
     // Process the test contract
     const result = await processContractWithPdfTemplate(
@@ -207,7 +236,6 @@ router.post('/test', async (req: Request, res: Response): Promise<void> => {
 });
 
 export default router;
-
 
 
 


### PR DESCRIPTION
## What changed

- removes the embedded SignNow bearer credential from current source
- requires SIGNNOW_ACCESS_TOKEN runtime injection and fails closed when absent
- restricts the PDF-contract router to authenticated admins
- disables the PDF-contract test workflow in production
- records the historical exposure without reproducing the credential
- adds credential-containment and 401/403 regression tests

## Why

A credential-shaped value was committed in a public PDF-contract route and remains present in Git history. Source removal prevents continued embedding but does not replace owner-coordinated rotation.

## Impact

PDF-contract operations now require admin authorization and injected provider configuration. Missing configuration returns 503. No credential was tested, rotated, revoked, deployed, or copied.

## Validation

- TypeScript no-emit compilation passed
- focused PDF authorization/containment tests passed: 4/4
- combined SEC-02 and AUTH-01B focused tests passed: 17/17
- relevant existing tests passed: 54/54
- diff check passed

## Required external follow-up

An authorized SignNow owner must determine whether the historical credential is active and coordinate replacement, deployment, verification, revocation, and audit evidence.