### PR TITLE
AUTH-01B: protect public provider and payment routes

### DIFF
--- a/src/__tests__/auth01bPublicRoutes.test.ts
+++ b/src/__tests__/auth01bPublicRoutes.test.ts
@@ -1,0 +1,93 @@
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../middleware/authMiddleware', () => ({
+  __esModule: true,
+  default: (req: any, res: any, next: any) => {
+    const role = req.get('x-test-role');
+    if (!role) {
+      res.status(401).json({ error: 'No session token provided' });
+      return;
+    }
+    req.user = { id: 'synthetic-user', email: 'synthetic@example.test', role };
+    next();
+  },
+}));
+
+jest.mock('../services/signNowService', () => ({
+  SignNowService: jest.fn().mockImplementation(() => ({ testAuthentication: jest.fn() })),
+  signNowService: { testAuthentication: jest.fn() },
+}));
+jest.mock('../utils/signNowContractProcessor', () => ({
+  checkSignNowDocumentStatus: jest.fn(),
+  processContractWithSignNow: jest.fn(),
+}));
+jest.mock('../controllers/signNowWebhookController', () => ({
+  signNowCallback: (_req: any, res: any) => res.sendStatus(204),
+}));
+jest.mock('../controllers/quickbooksController', () => ({
+  connectQuickBooks: jest.fn(),
+  createCustomer: jest.fn(),
+  createInvoice: jest.fn(),
+  getInvoiceableCustomersController: jest.fn(),
+  getInvoices: jest.fn(),
+  getQuickBooksCustomers: jest.fn(),
+  handleQuickBooksCallback: jest.fn(),
+  quickBooksAuthUrl: jest.fn(),
+  quickBooksDisconnect: jest.fn(),
+  quickBooksStatus: jest.fn(),
+  refreshQuickBooksCustomerSyncStatus: jest.fn(),
+}));
+jest.mock('../controllers/quickbooksWebhookController', () => ({ quickBooksInvoicePaidWebhook: jest.fn() }));
+jest.mock('../api/simulate-payment', () => ({ simulatePaymentController: jest.fn() }));
+jest.mock('../services/contractClientService', () => ({ ContractClientService: jest.fn() }));
+jest.mock('../services/simplePaymentService', () => ({ SimplePaymentService: jest.fn() }));
+jest.mock('../services/cloudSqlDoulaAssignmentService', () => ({ CloudSqlDoulaAssignmentService: jest.fn() }));
+jest.mock('../repositories/cloudSqlPaymentRepository', () => ({ listPaymentsFromCloudSql: jest.fn() }));
+
+import contractRoutes from '../routes/contractRoutes';
+import contractSigningRoutes from '../routes/contractSigningRoutes';
+import customersRoutes from '../routes/customersRoutes';
+import paymentRoutes from '../routes/paymentRoutes';
+import quickBooksRoutes from '../routes/quickbooksRoutes';
+import signNowRoutes from '../routes/signNowRoutes';
+
+const appFor = (prefix: string, router: express.Router) => {
+  const app = express();
+  app.use(express.json());
+  app.use(prefix, router);
+  return app;
+};
+
+describe('AUTH-01B public route protection', () => {
+  it.each([
+    ['/api/contract', contractRoutes, 'post', '/postpartum/calculate'],
+    ['/api/contract-signing', contractSigningRoutes, 'get', '/test-auth'],
+    ['/quickbooks/customers', customersRoutes, 'get', '/invoiceable'],
+    ['/quickbooks', quickBooksRoutes, 'get', '/status'],
+    ['/api/payments', paymentRoutes, 'get', '/dashboard'],
+    ['/api/signnow', signNowRoutes, 'post', '/test-auth'],
+  ] as const)('returns 401 for unauthenticated %s operational routes', async (prefix, router, method, path) => {
+    await (request(appFor(prefix, router))[method] as (path: string) => request.Test)(`${prefix}${path}`).expect(401);
+  });
+
+  it.each([
+    ['/api/contract', contractRoutes, 'post', '/postpartum/calculate', 'client'],
+    ['/api/contract-signing', contractSigningRoutes, 'get', '/test-auth', 'client'],
+    ['/quickbooks/customers', customersRoutes, 'get', '/invoiceable', 'doula'],
+    ['/quickbooks', quickBooksRoutes, 'get', '/status', 'doula'],
+    ['/api/payments', paymentRoutes, 'get', '/dashboard', 'client'],
+    ['/api/signnow', signNowRoutes, 'post', '/test-auth', 'client'],
+  ] as const)('returns 403 for unauthorized authenticated %s routes', async (prefix, router, method, path, role) => {
+    await (request(appFor(prefix, router))[method] as (path: string) => request.Test)(`${prefix}${path}`)
+      .set('x-test-role', role)
+      .expect(403);
+  });
+
+  it('keeps the SignNow provider callback outside user authentication', async () => {
+    await request(appFor('/api/signnow', signNowRoutes))
+      .post('/api/signnow/callback')
+      .send({ synthetic: true })
+      .expect(204);
+  });
+});

--- a/src/routes/contractRoutes.ts
+++ b/src/routes/contractRoutes.ts
@@ -2,8 +2,15 @@ import { Request, Response, Router } from 'express';
 import { calculatePostpartumContract, formatForSignNow, ValidationError } from '../services/postpartum/calculateContract';
 import { signNowService } from '../services/signNowService';
 import { PostpartumContractInput } from '../types/postpartum';
+import authMiddleware from '../middleware/authMiddleware';
+import authorizeRoles from '../middleware/authorizeRoles';
 
 const router = Router();
+
+router.use(
+  authMiddleware,
+  (req, res, next) => authorizeRoles(req, res, next, ['admin'])
+);
 
 router.post('/postpartum/calculate', async (req, res) => {
   try {

--- a/src/routes/contractSigningRoutes.ts
+++ b/src/routes/contractSigningRoutes.ts
@@ -2,8 +2,15 @@ import crypto from 'crypto';
 import { Request, Response, Router } from 'express';
 import { SignNowService } from '../services/signNowService';
 import { checkSignNowDocumentStatus, processContractWithSignNow, type SignNowContractData } from '../utils/signNowContractProcessor';
+import authMiddleware from '../middleware/authMiddleware';
+import authorizeRoles from '../middleware/authorizeRoles';
 
 const router = Router();
+
+router.use(
+  authMiddleware,
+  (req, res, next) => authorizeRoles(req, res, next, ['admin'])
+);
 
 interface ContractSigningRequest extends Request {
   body: SignNowContractData;

--- a/src/routes/customersRoutes.ts
+++ b/src/routes/customersRoutes.ts
@@ -1,8 +1,15 @@
 // src/features/quickbooks/routes/customersRoutes.js
 import { Router } from 'express';
+import authMiddleware from '../middleware/authMiddleware';
+import authorizeRoles from '../middleware/authorizeRoles';
 
 import { createCustomer, getInvoiceableCustomersController } from '../controllers/quickbooksController';
 const router = Router();
+
+router.use(
+  authMiddleware,
+  (req, res, next) => authorizeRoles(req, res, next, ['admin', 'billing'])
+);
 
 // POST /quickbooks/customers
 router.post('/', createCustomer);

--- a/src/routes/paymentRoutes.ts
+++ b/src/routes/paymentRoutes.ts
@@ -38,7 +38,7 @@ router.get('/', authMiddleware, (req, res, next) => authorizeRoles(req, res, nex
 router.get('', authMiddleware, (req, res, next) => authorizeRoles(req, res, next, ['admin', 'doula']), listPaymentsHandler);
 
 // Get payment dashboard
-router.get('/dashboard', async (req, res) => {
+router.get('/dashboard', authMiddleware, (req, res, next) => authorizeRoles(req, res, next, ['admin', 'billing']), async (req, res) => {
   try {
     const dashboard = await paymentService.getPaymentDashboard();
     res.json({ success: true, data: dashboard });
@@ -49,7 +49,7 @@ router.get('/dashboard', async (req, res) => {
 });
 
 // Get overdue payments
-router.get('/overdue', async (req, res) => {
+router.get('/overdue', authMiddleware, (req, res, next) => authorizeRoles(req, res, next, ['admin', 'billing']), async (req, res) => {
   try {
     const overdue = await paymentService.getOverduePayments();
     res.json({ success: true, data: overdue });
@@ -60,7 +60,7 @@ router.get('/overdue', async (req, res) => {
 });
 
 // Get payment summary for a contract
-router.get('/contract/:contractId/summary', async (req, res) => {
+router.get('/contract/:contractId/summary', authMiddleware, (req, res, next) => authorizeRoles(req, res, next, ['admin', 'billing', 'doula', 'client']), async (req, res) => {
   try {
     const { contractId } = req.params;
     const summary = await paymentService.getPaymentSummary(contractId);
@@ -72,7 +72,7 @@ router.get('/contract/:contractId/summary', async (req, res) => {
 });
 
 // Get payment schedule for a contract
-router.get('/contract/:contractId/schedule', async (req, res) => {
+router.get('/contract/:contractId/schedule', authMiddleware, (req, res, next) => authorizeRoles(req, res, next, ['admin', 'billing', 'doula', 'client']), async (req, res) => {
   try {
     const { contractId } = req.params;
     const schedule = await paymentService.getPaymentSchedule(contractId);
@@ -116,7 +116,7 @@ router.get(
 });
 
 // Update payment status
-router.put('/payment/:paymentId/status', async (req: Request, res: Response): Promise<void> => {
+router.put('/payment/:paymentId/status', authMiddleware, (req, res, next) => authorizeRoles(req, res, next, ['admin', 'billing']), async (req: Request, res: Response): Promise<void> => {
   try {
     const { paymentId } = req.params;
     const { status, stripe_payment_intent_id, notes } = req.body;
@@ -140,7 +140,7 @@ router.put('/payment/:paymentId/status', async (req: Request, res: Response): Pr
 });
 
 // Get payments by status
-router.get('/status/:status', async (req: Request, res: Response): Promise<void> => {
+router.get('/status/:status', authMiddleware, (req, res, next) => authorizeRoles(req, res, next, ['admin', 'billing']), async (req: Request, res: Response): Promise<void> => {
   try {
     const { status } = req.params;
     const payments = await paymentService.getPaymentsByStatus(status as 'pending' | 'succeeded' | 'failed' | 'canceled' | 'refunded');
@@ -152,7 +152,7 @@ router.get('/status/:status', async (req: Request, res: Response): Promise<void>
 });
 
 // Get payments due within a date range
-router.get('/due-between', async (req: Request, res: Response): Promise<void> => {
+router.get('/due-between', authMiddleware, (req, res, next) => authorizeRoles(req, res, next, ['admin', 'billing']), async (req: Request, res: Response): Promise<void> => {
   try {
     const { start_date, end_date } = req.query;
 
@@ -176,7 +176,7 @@ router.get('/due-between', async (req: Request, res: Response): Promise<void> =>
 });
 
 // Run daily maintenance (for cron jobs or manual triggers)
-router.post('/maintenance/daily', async (req, res) => {
+router.post('/maintenance/daily', authMiddleware, (req, res, next) => authorizeRoles(req, res, next, ['admin']), async (req, res) => {
   try {
     await paymentService.runDailyMaintenance();
     res.json({ success: true, message: 'Daily payment maintenance completed' });
@@ -187,7 +187,7 @@ router.post('/maintenance/daily', async (req, res) => {
 });
 
 // Update overdue flags manually
-router.post('/maintenance/overdue-flags', async (req, res) => {
+router.post('/maintenance/overdue-flags', authMiddleware, (req, res, next) => authorizeRoles(req, res, next, ['admin']), async (req, res) => {
   try {
     await paymentService.updateOverdueFlags();
     res.json({ success: true, message: 'Overdue flags updated' });

--- a/src/routes/quickbooksRoutes.ts
+++ b/src/routes/quickbooksRoutes.ts
@@ -14,6 +14,7 @@ import {
   refreshQuickBooksCustomerSyncStatus
 } from '../controllers/quickbooksController'
 import authMiddleware from '../middleware/authMiddleware'
+import authorizeRoles from '../middleware/authorizeRoles'
 import { quickBooksInvoicePaidWebhook } from '../controllers/quickbooksWebhookController'
 import { simulatePaymentController } from '../services/payments/paymentsController'
 
@@ -25,6 +26,7 @@ router.get('/callback', handleQuickBooksCallback)
 
 // 2️⃣ Now apply auth + admin guard to the rest
 router.use(authMiddleware)
+router.use((req, res, next) => authorizeRoles(req, res, next, ['admin', 'billing']))
 
 // 3️⃣ Protected AJAX endpoints
 router.get('/auth/url', quickBooksAuthUrl)

--- a/src/routes/signNowRoutes.ts
+++ b/src/routes/signNowRoutes.ts
@@ -1,6 +1,8 @@
 import { Request, Response, Router } from 'express';
 import { signNowCallback } from '../controllers/signNowWebhookController';
 import { signNowService } from '../services/signNowService';
+import authMiddleware from '../middleware/authMiddleware';
+import authorizeRoles from '../middleware/authorizeRoles';
 
 const router = Router();
 
@@ -22,7 +24,11 @@ interface SignNowRequest extends Request {
 }
 
 // Test authentication
-router.post('/test-auth', async (_req: Request, res: Response): Promise<void> => {
+router.post(
+  '/test-auth',
+  authMiddleware,
+  (req, res, next) => authorizeRoles(req, res, next, ['admin']),
+  async (_req: Request, res: Response): Promise<void> => {
   try {
     const result = await signNowService.testAuthentication();
     res.json(result);
@@ -33,10 +39,17 @@ router.post('/test-auth', async (_req: Request, res: Response): Promise<void> =>
       error: error instanceof Error ? error.message : 'Authentication test failed'
     });
   }
-});
+  }
+);
 
 // SignNow webhook callback for document completion
 router.post('/callback', signNowCallback);
+
+// Provider callback remains public; every operational SignNow action below is admin-only.
+router.use(
+  authMiddleware,
+  (req, res, next) => authorizeRoles(req, res, next, ['admin'])
+);
 
 // Test template access
 router.post('/test-template', async (_req: Request, res: Response): Promise<void> => {


### PR DESCRIPTION
## What changed

- protects operational SignNow, contract, contract-signing, payment, QuickBooks, and QuickBooks-customer routes
- applies explicit admin or billing roles based on the AUTH-01A matrix
- preserves the public SignNow provider callback boundary
- adds representative unauthenticated 401 and unauthorized-role 403 tests

## Why

Multiple production-mounted operational routes were reachable without user authentication or without a sufficiently narrow role check.

## Impact

Previously public provider and financial operations now require authenticated roles. Resource ownership and doula assignment enforcement remain scoped to AUTH-01C.

## Validation

- TypeScript no-emit compilation passed
- combined authorization and credential tests passed: 17/17
- relevant billing, SignNow, contract, and QuickBooks tests passed: 54/54
- diff check passed

## Review focus

Confirm middleware ordering, role classifications, the provider-callback exception, and that ownership-dependent decisions are deferred to AUTH-01C.